### PR TITLE
Add CI steps for RuboCop and RSpec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,5 +23,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Run the default task
-      run: bundle exec rake
+    - name: Run RuboCop
+      run: bundle exec rubocop
+    - name: Run RSpec
+      run: bundle exec rspec


### PR DESCRIPTION
## Summary
- run RuboCop and RSpec separately in GitHub Actions

## Testing
- `bundle exec rake`